### PR TITLE
Assert Docker Candidate Execution Boundary mount allowlist

### DIFF
--- a/tests/test_execution_backends.py
+++ b/tests/test_execution_backends.py
@@ -106,6 +106,12 @@ def test_docker_backend_constructs_structurally_contained_smoke_command(tmp_path
     assert f"{run_dir / 'run_metadata.json'}:/run_metadata.json:ro,z" in joined
     assert f"{run_dir / 'outputs'}:/outputs:rw,z" in joined
     assert "type=tmpfs,destination=/scratch,tmpfs-size=2g,tmpfs-mode=1777" in joined
+    volume_targets = [
+        docker_run[index + 1].split(":", 1)[1].split(":", 1)[0]
+        for index, value in enumerate(docker_run)
+        if value == "--volume"
+    ]
+    assert volume_targets == ["/candidate", "/resolved_manifest.yaml", "/run_metadata.json", "/outputs"]
     assert "/var/run/docker.sock" not in joined
 
 

--- a/tests/test_synthetic_backend_training.py
+++ b/tests/test_synthetic_backend_training.py
@@ -170,6 +170,12 @@ def test_docker_backend_constructs_gvccs_training_command_with_read_only_data_mo
     assert f"{data_root}:/data:ro,z" in joined
     assert f"{run_dir / 'candidate'}:/candidate:ro,z" in joined
     assert f"{run_dir / 'outputs'}:/outputs:rw,z" in joined
+    volume_targets = [
+        docker_run[index + 1].split(":", 1)[1].split(":", 1)[0]
+        for index, value in enumerate(docker_run)
+        if value == "--volume"
+    ]
+    assert volume_targets == ["/candidate", "/resolved_manifest.yaml", "/run_metadata.json", "/outputs", "/data"]
     assert "/data" in joined
     assert f"{data_root}:/data:z" not in joined
 


### PR DESCRIPTION
> *This was generated by AI.*

Closes #12.

## Summary
- Adds explicit regression assertions that Docker smoke-test mounts are limited to the approved read-only inputs plus writable `/outputs`.
- Adds explicit regression assertions that Docker GVCCS training mounts are limited to the approved read-only inputs, writable `/outputs`, and read-only `/data`.

## Tests
- `uv run --extra dev pytest tests/test_execution_backends.py tests/test_synthetic_backend_training.py`
- `uv run --extra dev pytest` (fails in this environment because `tests/test_cli_submission.py::test_submit_candidate_cli_creates_run_and_prints_json` receives a PyTorch CUDA driver warning on stderr; all other tests passed, with Docker integration tests skipped)
