### PR TITLE
Record research problem identity in run artifacts

### DIFF
--- a/src/ml_autoresearch/runs.py
+++ b/src/ml_autoresearch/runs.py
@@ -18,6 +18,7 @@ from ml_autoresearch.candidates import CandidateValidationError, validate_candid
 from ml_autoresearch.errors import GVCCSDataError, SmokeTestError, TrainingError
 from ml_autoresearch.execution import DockerOperationTimeoutError, ExecutionBackend, NativeBackend, backend_metadata
 from ml_autoresearch.research_ledger import CANONICAL_RESEARCH_LEDGER, ResearchLedgerError, record_research_event
+from ml_autoresearch.research_problems import get_research_problem_spec
 
 
 class RunStatus(StrEnum):
@@ -522,6 +523,8 @@ def _read_run_summary_dir(run_dir: Path) -> dict[str, object]:
         summary["reason"] = reason
     if metadata.get("failure_classification") is not None:
         summary["failure_classification"] = metadata["failure_classification"]
+    if isinstance(metadata.get("research_problem"), dict):
+        summary["research_problem"] = metadata["research_problem"]
     if "artifacts" in metadata:
         summary["artifacts"] = metadata["artifacts"]
 
@@ -599,8 +602,14 @@ def _read_evaluation_summary_dir(evaluation_dir: Path) -> dict[str, object]:
     return summary
 
 
+def _research_problem_identity(manifest: object) -> dict[str, str]:
+    spec = get_research_problem_spec(str(getattr(manifest, "research_problem")))
+    return {"id": spec.id, "version": spec.version}
+
+
 def _resolved_manifest_payload(manifest: object) -> dict[str, object]:
     payload = manifest.model_dump(mode="json")
+    payload["research_problem"] = _research_problem_identity(manifest)
     data_policy = payload.setdefault("data", {})
     selected = data_policy.get("augmentation_policy", "none")
     data_policy["augmentation_policy"] = selected
@@ -716,6 +725,7 @@ def submit_candidate(
         )
         return RunSubmission(run_id, run_dir, RunStatus.REJECTED, repair_policy_reason, RunFailureClassification.CONTRACT_VIOLATION)
 
+    research_problem = _research_problem_identity(manifest)
     validation_log.write_text("Candidate validation accepted.\n")
     proposal_path = source / "PROPOSAL.md"
     if proposal_path.is_file():
@@ -735,6 +745,7 @@ def submit_candidate(
         training_failure_reason=None,
         execution_backend=execution_backend_metadata,
         repair_lineage=repair_lineage,
+        research_problem=research_problem,
     )
 
     try:
@@ -1007,6 +1018,7 @@ def _write_metadata(
     dataset: dict[str, object] | None = None,
     training_lifecycle: dict[str, object] | None = None,
     repair_lineage: dict[str, object] | None = None,
+    research_problem: dict[str, str] | None = None,
 ) -> None:
     existing_metadata = None
     metadata_path = run_dir / "run_metadata.json"
@@ -1033,6 +1045,10 @@ def _write_metadata(
         "smoke_failure_reason": smoke_failure_reason,
         "training_failure_reason": training_failure_reason,
     }
+    if research_problem is not None:
+        metadata["research_problem"] = research_problem
+    elif isinstance(existing_metadata, dict) and isinstance(existing_metadata.get("research_problem"), dict):
+        metadata["research_problem"] = existing_metadata["research_problem"]
     if execution_backend is not None:
         metadata["execution_backend"] = execution_backend
     if dataset is not None:

--- a/tests/test_gvccs_data.py
+++ b/tests/test_gvccs_data.py
@@ -101,6 +101,7 @@ def test_run_candidate_with_gvccs_fixture_trains_one_epoch(tmp_path: Path):
             assert image.size == (128, 128)
     assert "GVCCS" in (run.run_dir / "outputs" / "logs" / "training.log").read_text()
     metadata = json.loads((run.run_dir / "run_metadata.json").read_text())
+    assert metadata["research_problem"] == {"id": "ground_camera_contrail_detection", "version": "v0"}
     assert metadata["dataset"] == {
         "id": "gvccs",
         "host_data_path": str(FIXTURE_ROOT.resolve()),

--- a/tests/test_run_observation.py
+++ b/tests/test_run_observation.py
@@ -16,6 +16,7 @@ def write_run(
     reason: str | None = None,
     best_dice: float | None = None,
     failure_classification: str | None = None,
+    research_problem: dict[str, str] | None = None,
 ) -> Path:
     run_dir = runs_root / run_id
     run_dir.mkdir(parents=True)
@@ -30,6 +31,8 @@ def write_run(
         "training_failure_reason": reason if status == "failed" else None,
         "failure_classification": failure_classification,
     }
+    if research_problem is not None:
+        metadata["research_problem"] = research_problem
     (run_dir / "run_metadata.json").write_text(json.dumps(metadata) + "\n")
     if dice is not None:
         outputs_dir = run_dir / "outputs"
@@ -121,12 +124,20 @@ def test_agent_cli_list_runs_table_prints_empty_reason_when_reason_is_missing(tm
 
 def test_get_run_summary_reads_one_run_without_mlflow(tmp_path: Path):
     runs_root = tmp_path / "runs"
-    write_run(runs_root, "run_done", "completed", 0.82, best_dice=0.9)
+    write_run(
+        runs_root,
+        "run_done",
+        "completed",
+        0.82,
+        best_dice=0.9,
+        research_problem={"id": "ground_camera_contrail_detection", "version": "v0"},
+    )
 
     summary = get_run_summary(runs_root, "run_done")
 
     assert summary["run_id"] == "run_done"
     assert summary["status"] == "completed"
+    assert summary["research_problem"] == {"id": "ground_camera_contrail_detection", "version": "v0"}
     assert summary["metrics"]["val/dice"] == 0.82
     assert summary["best_metrics"]["selection_metric"] == "val/dice"
     assert summary["best_metrics"]["selection_value"] == 0.9

--- a/tests/test_run_submission.py
+++ b/tests/test_run_submission.py
@@ -61,6 +61,7 @@ def test_submit_candidate_creates_accepted_run_directory(tmp_path: Path):
     resolved = yaml.safe_load((run_dir / "resolved_manifest.yaml").read_text())
     assert resolved["name"] == "single_frame_unet_baseline"
     assert resolved["description"] == "Tiny single-frame mask-only baseline for harness validation."
+    assert resolved["research_problem"] == {"id": "ground_camera_contrail_detection", "version": "v0"}
     assert resolved["input_mode"] == "single_frame_rgb"
     assert resolved["output_form"] == "mask_logits"
     assert resolved["auxiliary_targets"] == []
@@ -73,6 +74,7 @@ def test_submit_candidate_creates_accepted_run_directory(tmp_path: Path):
     assert metadata["run_id"] == run.run_id
     assert metadata["status"] == "accepted"
     assert metadata["candidate_source"]["path"] == str(candidate.resolve())
+    assert metadata["research_problem"] == {"id": "ground_camera_contrail_detection", "version": "v0"}
     assert metadata["rejection_reason"] is None
     assert metadata["created_at"]
     assert metadata["updated_at"]

--- a/tests/test_synthetic_training.py
+++ b/tests/test_synthetic_training.py
@@ -122,6 +122,7 @@ def test_run_candidate_with_synthetic_fixture_writes_result_artifacts(tmp_path: 
     run_dir = run.run_dir
     metadata = json.loads((run_dir / "run_metadata.json").read_text())
     assert metadata["status"] == "completed"
+    assert metadata["research_problem"] == {"id": "ground_camera_contrail_detection", "version": "v0"}
     assert metadata["training_failure_reason"] is None
     assert metadata["artifacts"]["prediction_samples"] == "outputs/prediction_samples/samples.json"
     assert metadata["artifacts"]["best_metrics"] == "outputs/best_metrics.json"


### PR DESCRIPTION
> *This was generated by AI.*

Closes #74

## Summary
- record resolved Research Problem id/version in `resolved_manifest.yaml`
- persist the same identity in `run_metadata.json` across Run lifecycle updates
- expose Research Problem identity in local Run observation summaries

## Tests
- `.venv/bin/python -m pytest tests/test_run_submission.py tests/test_run_observation.py tests/test_research_problem_specs.py tests/test_candidate_contract.py -q`
- `.venv/bin/python -m pytest tests/test_synthetic_training.py tests/test_gvccs_data.py -q`

## Notes
- Existing source manifests that omit research_problem continue to resolve to `ground_camera_contrail_detection` v0.